### PR TITLE
dep: missing clasp on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.0",
+    "@google/clasp": "^2.4.1",
     "lodash": "^4.17.11",
     "moment": "^2.24.0"
   }


### PR DESCRIPTION
running `npm i && npm deploy` fails at `clasp push` if the package isn't already installed globally.  much safer to include clasp as a project dependency.